### PR TITLE
Only delete posframe when there is a which-key--buffer.

### DIFF
--- a/which-key-posframe.el
+++ b/which-key-posframe.el
@@ -136,7 +136,8 @@ characters respectably."
     (setq which-key-custom-popup-max-dimensions-function
           'which-key-posframe--max-dimensions))
    (t
-    (posframe-delete which-key--buffer)
+    (when which-key--buffer
+      (posframe-delete which-key--buffer))
     (setq which-key-popup-type
           which-key-popup-type--previous)
     (setq which-key-custom-show-popup-function


### PR DESCRIPTION
I added a check to see if `which-key--buffer` actually has a value before handing it over to `posframe-delete` in `which-key-posframe-mode`.

Fixes #3 